### PR TITLE
Add timeouts to action server wait_for_* calls

### DIFF
--- a/scripts/gripper_action_client.py
+++ b/scripts/gripper_action_client.py
@@ -58,6 +58,7 @@ class GripperClient(object):
         if not self._client.wait_for_server(rospy.Duration(10.0)):
             rospy.logerr("Exiting - %s Gripper Action Server Not Found" %
                          (gripper.capitalize(),))
+            rospy.signal_shutdown("Action Server not found")
             sys.exit(1)
         self.clear()
 
@@ -69,8 +70,8 @@ class GripperClient(object):
     def stop(self):
         self._client.cancel_goal()
 
-    def wait(self):
-        self._client.wait_for_result()
+    def wait(self, timeout=5.0):
+        self._client.wait_for_result(timeout=rospy.Duration(timeout))
         return self._client.get_result()
 
     def clear(self):

--- a/scripts/joint_trajectory_file_playback.py
+++ b/scripts/joint_trajectory_file_playback.py
@@ -72,7 +72,7 @@ class Trajectory(object):
         r_server_up = self._right_client.wait_for_server(rospy.Duration(1.0))
         if not l_server_up or not r_server_up:
             msg = ("Action server not available."
-                   " Verify controller availability.")
+                   " Verify action server availability.")
             rospy.logerr(msg)
             rospy.signal_shutdown(msg)
             sys.exit(1)
@@ -105,7 +105,7 @@ class Trajectory(object):
         self._r_grip = FollowJointTrajectoryGoal()
 
         #param namespace
-        self._param_ns = '/rethink_rsdk_joint_trajectory_action_server/'
+        self._param_ns = '/rsdk_joint_trajectory_action_server/'
 
         #gripper control rate
         self._gripper_rate = 20.0  # Hz


### PR DESCRIPTION
Add timeouts to wait_for_server() and wait_for_result() calls in action clients, so that they will not wait indefinitely.

Also added name change to traj playback _param_ns.
