### PR TITLE
Fix D-Pad button mappings on ps3 joystick

### DIFF
--- a/src/baxter_io_devices/joystick.py
+++ b/src/baxter_io_devices/joystick.py
@@ -273,10 +273,10 @@ class PS3Controller(Joystick):
         self._controls['btnDown'] = (msg.buttons[14] == 1)
         self._controls['btnRight'] = (msg.buttons[13] == 1)
 
-        self._controls['dPadUp'] = (msg.axes[4] > 0.5)
-        self._controls['dPadDown'] = (msg.axes[6] < -0.5)
-        self._controls['dPadLeft'] = (msg.axes[7] > 0.5)
-        self._controls['dPadRight'] = (msg.axes[5] < -0.5)
+        self._controls['dPadUp'] = (msg.buttons[4] == 1)
+        self._controls['dPadDown'] = (msg.buttons[6] == 1)
+        self._controls['dPadLeft'] = (msg.buttons[7] == 1)
+        self._controls['dPadRight'] = (msg.buttons[5] == 1)
 
         self._controls['leftStickHorz'] = msg.axes[0]
         self._controls['leftStickVert'] = msg.axes[1]


### PR DESCRIPTION
The ps3 joystick mappings in the joystick.py library were incorrect
for the D-Pad - specifically for D-Pad Left and Up did not work.
This fix switches them from thresholding the /joy message axes to
using the buttons array instead.
- Replace ps3 d-pad mappings with buttons instead of axes
  thresholding.
- ps3 joysticks have different axes scaling when connected via USB
  or BT - plus, Left and Up on D-Pad do not work in the former.
- buttons array works and is consistent in all cases.
