### PR TITLE
Remove default from joystick arg in roslaunchs

### DIFF
--- a/launch/gripper_joystick.launch
+++ b/launch/gripper_joystick.launch
@@ -1,10 +1,10 @@
 <launch>
 
+  <!-- Joystick Type Argument: {xbox, ps3, logitech} -->
+  <arg name="joystick" />
+
   <!-- Joystick Device Argument-->
   <arg name="dev" default="/dev/input/js0" />
-
-  <!-- Joystick Argument -->
-  <arg name="joystick" default="xbox" />
 
   <!-- Start the Joy Node -->
   <node name="joy_node" pkg="joy"

--- a/launch/joint_position_joystick.launch
+++ b/launch/joint_position_joystick.launch
@@ -1,10 +1,10 @@
 <launch>
 
+  <!-- Joystick Type Argument: {xbox, ps3, logitech} -->
+  <arg name="joystick" />
+
   <!-- Joystick Device Argument-->
   <arg name="dev" default="/dev/input/js0" />
-
-  <!-- Joystick Argument -->
-  <arg name="joystick" default="xbox" />
 
   <!-- Start the Joy Node -->
   <node name="joy_node" pkg="joy"


### PR DESCRIPTION
Removes the default value for the joystick arg (joystick type)
in all roslaunch files for joystick examples. This matches the
examples themselves which require the --joystick arg to be
explicitly passed.
- Use ROS Remapping to pass joystick argument:
  $ roslaunch baxter_examples gripper_joystick.launch joystick:=ps3
- Accepted values are: {xbox, ps3, logitech}. (Also noted in
  launch file comments.
