### PR TITLE
epydoc docstring formatting for rosdoc generation

### DIFF
--- a/scripts/gripper_cuff_control.py
+++ b/scripts/gripper_cuff_control.py
@@ -49,8 +49,10 @@ class GripperConnect(object):
 
     def __init__(self, arm, lights=True):
         """
-        @param arm (str):     arm of gripper to control {left, right}
-        @param lights (bool): if lights should activate on cuff grasp
+        @type arm: str
+        @param arm: arm of gripper to control {left, right}
+        @type lights: bool
+        @param lights: if lights should activate on cuff grasp
         """
         self._arm = arm
         # inputs

--- a/scripts/gripper_joystick.py
+++ b/scripts/gripper_joystick.py
@@ -41,7 +41,8 @@ import baxter_external_devices
 def map_joystick(joystick):
     """
     maps joystick input to gripper commands
-    @param joystick - an instance of a Joystick
+
+    @param joystick: an instance of a Joystick
     """
     # initialize interfaces
     print("Getting robot state... ")

--- a/scripts/joint_position_file_playback.py
+++ b/scripts/joint_position_file_playback.py
@@ -46,9 +46,11 @@ def try_float(x):
 
 
 def clean_line(line, names):
-    """ Cleans a single line of recorded joint positions
-    @param line - the line described in a list to process
-    @param names - joint name keys
+    """
+    Cleans a single line of recorded joint positions
+
+    @param line: the line described in a list to process
+    @param names: joint name keys
     """
     #convert the line of strings to a float or None
     line = [try_float(x) for x in line.rstrip().split(',')]
@@ -66,15 +68,18 @@ def clean_line(line, names):
 
 
 def map_file(filename, loops=1):
-    """ Loops through csv file
+    """
+    Loops through csv file
+
+    @param filename: the file to play
+    @param loops: number of times to loop
+                  values < 0 mean 'infinite'
+
     Does not loop indefinitely, but only until the file is read
     and processed. Reads each line, split up in columns and
     formats each line into a controller command in the form of
     name/value pairs. Names come from the column headers
     first column is the time stamp
-    @param filename - the file to play
-    @param loops - number of times to loop
-        values < 0 mean 'infinite'
     """
     left = baxter_interface.Limb('left')
     right = baxter_interface.Limb('right')

--- a/scripts/joint_position_joystick.py
+++ b/scripts/joint_position_joystick.py
@@ -40,9 +40,9 @@ import baxter_external_devices
 
 def rotate(l):
     """
-    @param l - the list
-
     Rotates a list left.
+
+    @param l: the list
     """
     if len(l):
         v = l[0]
@@ -52,13 +52,13 @@ def rotate(l):
 
 def set_j(cmd, limb, joints, index, delta):
     """
-    @param cmd - the joint command dictionary
-    @param limb - the limb to get the pos from
-    @param joints - a list of joint names
-    @param index - the index in the list of names
-    @param delta - delta to update the joint by
-
     Set the selected joint to current pos + delta.
+
+    @param cmd: the joint command dictionary
+    @param limb: the limb to get the pos from
+    @param joints: a list of joint names
+    @param index: the index in the list of names
+    @param delta: delta to update the joint by
 
     joint/index is to make this work in the bindings.
     """
@@ -68,9 +68,9 @@ def set_j(cmd, limb, joints, index, delta):
 
 def map_joystick(joystick):
     """
-    @param joystick - an instance of a Joystick
-
     Maps joystick input to joint position commands.
+
+    @param joystick: an instance of a Joystick
     """
     left = baxter_interface.Limb('left')
     right = baxter_interface.Limb('right')

--- a/scripts/joint_torque_springs.py
+++ b/scripts/joint_torque_springs.py
@@ -50,8 +50,10 @@ from baxter_examples.cfg import (
 
 class JointSprings(object):
     """
-    @param limb - limb on which to run joint springs example
-    @param reconfig_server - dynamic reconfigure server
+    Virtual Joint Springs class for torque example.
+
+    @param limb: limb on which to run joint springs example
+    @param reconfig_server: dynamic reconfigure server
 
     JointSprings class contains methods for the joint torque example allowing
     moving the limb to a neutral location, entering torque mode, and attaching

--- a/scripts/joint_trajectory_file_playback.py
+++ b/scripts/joint_trajectory_file_playback.py
@@ -128,13 +128,13 @@ class Trajectory(object):
 
     def _clean_line(self, line, joint_names):
         """
-        @param line - the line described in a list to process
-        @param joint_names - joint name keys
-
-        @return command - returns dictionary {joint: value} of valid commands
-        @return line - returns list of current line values stripped of commas
-
         Cleans a single line of recorded joint positions
+
+        @param line: the line described in a list to process
+        @param joint_names: joint name keys
+
+        @return command: returns dictionary {joint: value} of valid commands
+        @return line: returns list of current line values stripped of commas
         """
         def try_float(x):
             try:
@@ -153,11 +153,11 @@ class Trajectory(object):
 
     def _add_point(self, positions, side, time):
         """
-        @param positions - joint positions
-        @param side - limb to command point
-        @param time - time from start for point in seconds
-
         Appends trajectory with new point
+
+        @param positions: joint positions
+        @param side: limb to command point
+        @param time: time from start for point in seconds
         """
         #creates a point in trajectory with time_from_start and positions
         point = JointTrajectoryPoint()
@@ -174,9 +174,9 @@ class Trajectory(object):
 
     def parse_file(self, filename):
         """
-        @param filename - input filename
-
         Parses input file into FollowJointTrajectoryGoal format
+
+        @param filename: input filename
         """
         #open recorded file
         with open(filename, 'r') as f:

--- a/scripts/joint_velocity_puppet.py
+++ b/scripts/joint_velocity_puppet.py
@@ -43,10 +43,10 @@ class Puppeteer(object):
 
     def __init__(self, limb, amplification=1.0):
         """
-        @param limb - the control arm used to puppet the other
-        @param amplification - factor by which to amplify the arm movement
-
         Puppets one arm with the other.
+
+        @param limb: the control arm used to puppet the other
+        @param amplification: factor by which to amplify the arm movement
         """
         puppet_arm = {"left": "right", "right": "left"}
         self._control_limb = limb

--- a/scripts/xdisplay_image.py
+++ b/scripts/xdisplay_image.py
@@ -46,7 +46,7 @@ def send_image(path):
     Send the image located at the specified path to the head
     display on Baxter.
 
-    @param path - path to the image file to load and send
+    @param path: path to the image file to load and send
     """
     img = cv.LoadImage(path)
     msg = cv_bridge.CvBridge().cv_to_imgmsg(img, encoding="bgr8")

--- a/src/baxter_external_devices/joystick.py
+++ b/src/baxter_external_devices/joystick.py
@@ -110,11 +110,14 @@ class Joystick(object):
 
     def __init__(self, scale=1.0, offset=0.0, deadband=0.1):
         """
-        @param scale (float) - scaling applied to joystick values [1.0]
-        @param offset (float) - joystick offset values, post-scaling [0.0]
-        @param deadband (float) - deadband post scaling and offset [0.1]
-
         Maps joystick input to robot control.
+
+        @type scale: float
+        @param scale: scaling applied to joystick values [1.0]
+        @type offset: float
+        @param offset: joystick offset values, post-scaling [0.0]
+        @type deadband: float
+        @param deadband: deadband post scaling and offset [0.1]
 
         Raw joystick valuess are in [1.0...-1.0].
         """


### PR DESCRIPTION
Formatting mostly params in the docstrings to conform to epydoc syntax, so rosdoc_lite can properly parse and auto generate docs in the future.
