### PR TITLE
package.xml verification/fixes for new repos

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,10 +12,10 @@
   <license>BSD</license>
   <url type="website">http://www.rethinkrobotics.com/sdk</url>
   <url type="repository">
-    https://github.com/RethinkRobotics/sdk-examples
+    https://github.com/RethinkRobotics/baxter_examples
   </url>
   <url type="bugtracker">
-    https://github.com/RethinkRobotics/sdk-examples/issues
+    https://github.com/RethinkRobotics/baxter_examples/issues
   </url>
   <author>Rethink Robotics Inc.</author>
 


### PR DESCRIPTION
Verifying package.xml and version numbers for 0.7.0 release
and the rename and breakout of the Baxter SDK repositories,
especially 'sdk-examples' -> 'baxter'
