### PR TITLE
Add initial calibration warning to gripper_cuff

### DIFF
--- a/scripts/gripper_cuff_control.py
+++ b/scripts/gripper_cuff_control.py
@@ -67,6 +67,10 @@ class GripperConnect(object):
         # connect callback fns to signals
         if self._gripper.type() != 'custom':
             self._gripper.calibrate()
+            if not self._gripper.calibrated():
+                rospy.logwarn("%s (%s) calibration failed.",
+                              self._gripper.name.capitalize(),
+                              self._gripper.type())
         else:
             msg = (("%s (%s) not capable of gripper commands."
                    " Running cuff-light connection only.") %


### PR DESCRIPTION
Warns the user if calibration fails when the gripper_cuff_control
example first starts up. Future calibrations will not warn.
Also corresponds to gripper signal bug, but no changes here needed.
