### PR TITLE
Joint Trajectory Launch and Example Fixes

### DIFF
--- a/launch/joint_trajectory_client.launch
+++ b/launch/joint_trajectory_client.launch
@@ -5,7 +5,7 @@
 
   <!-- Start the Joint Trajectory Action Server -->
   <node name="rsdk_joint_trajectory_action_server" pkg="baxter_interface"
-  type="joint_trajectory_action_server.py" args="--limb $(arg limb)"
+  type="joint_trajectory_action_server.py" args="--limb $(arg limb) --mode position"
   required="true" />
 
   <!-- Run the Joint Trajectory Action Test Example -->

--- a/scripts/joint_trajectory_client.py
+++ b/scripts/joint_trajectory_client.py
@@ -60,6 +60,8 @@ class Trajectory(object):
             FollowJointTrajectoryAction,
         )
         self._goal = FollowJointTrajectoryGoal()
+        self._goal_time_tolerance = rospy.Time(0.1)
+        self._goal.goal_time_tolerance = self._goal_time_tolerance
         server_up = self._client.wait_for_server(timeout=rospy.Duration(10.0))
         if not server_up:
             rospy.logerr("Timed out waiting for Joint Trajectory"
@@ -90,6 +92,7 @@ class Trajectory(object):
 
     def clear(self, limb):
         self._goal = FollowJointTrajectoryGoal()
+        self._goal.goal_time_tolerance = self._goal_time_tolerance
         self._goal.trajectory.joint_names = [limb + '_' + joint for joint in \
             ['s0', 's1', 'e0', 'e1', 'w0', 'w1', 'w2']]
 

--- a/scripts/joint_trajectory_file_playback.py
+++ b/scripts/joint_trajectory_file_playback.py
@@ -68,8 +68,8 @@ class Trajectory(object):
         )
 
         #verify joint trajectory action servers are available
-        l_server_up = self._left_client.wait_for_server(rospy.Duration(1.0))
-        r_server_up = self._right_client.wait_for_server(rospy.Duration(1.0))
+        l_server_up = self._left_client.wait_for_server(rospy.Duration(10.0))
+        r_server_up = self._right_client.wait_for_server(rospy.Duration(10.0))
         if not l_server_up or not r_server_up:
             msg = ("Action server not available."
                    " Verify action server availability.")


### PR DESCRIPTION
- Preserved old functionality by specifying position mode in
  joint_trajectory_client.launch (position_w_id is default now)
- Added goal_time_tolerance of 0.1 to joint_trajectory_client.py to be a
  bit more lenient in achieving goal velocities of 0.0
- Upped the "wait for server" time in joint_trajectory_file_playback to
  10.0 seconds from 1.0 seconds (which was not enough time)