### PR TITLE
Core msgs sync

### DIFF
--- a/scripts/digital_io_blink.py
+++ b/scripts/digital_io_blink.py
@@ -34,7 +34,7 @@ import rospy
 import baxter_interface.digital_io as DIO
 
 
-def test_interface(io_component='left_itb_light_outer'):
+def test_interface(io_component='left_outer_light'):
     """Blinks a Digital Output on then off."""
     rospy.loginfo("Blinking Digital Output: %s", io_component)
     b = DIO.DigitalIO(io_component)
@@ -83,9 +83,9 @@ Baxter DigitalIO
                                      epilog=epilog)
     parser.add_argument(
         '-c', '--component', dest='component_id',
-        default='left_itb_light_outer',
+        default='left_outer_light',
         help=('name of Digital IO component to use'
-              ' (default: left_itb_light_outer)')
+              ' (default: left_outer_light)')
     )
     args = parser.parse_args(rospy.myargv()[1:])
 

--- a/scripts/head_action_client.py
+++ b/scripts/head_action_client.py
@@ -101,15 +101,15 @@ def main():
     print("Running. Ctrl-c to quit")
 
     hc = HeadClient()
-    hc.command(position=0.0, velocity=100.0)
+    hc.command(position=0.0, velocity=1.0)
     hc.wait()
-    hc.command(position=1.57, velocity=10.0)
+    hc.command(position=1.57, velocity=0.1)
     hc.wait()
-    hc.command(position=0.0, velocity=80.0)
+    hc.command(position=0.0, velocity=0.8)
     hc.wait()
-    hc.command(position=-1.0, velocity=40.0)
+    hc.command(position=-1.0, velocity=0.4)
     hc.wait()
-    hc.command(position=0.0, velocity=60.0)
+    hc.command(position=0.0, velocity=0.6)
     print hc.wait()
     print "Exiting - Head Action Test Example Complete"
 

--- a/scripts/head_wobbler.py
+++ b/scripts/head_wobbler.py
@@ -86,7 +86,7 @@ class Wobbler(object):
             while (not rospy.is_shutdown() and
                    not (abs(self._head.pan() - angle) <=
                        baxter_interface.HEAD_PAN_ANGLE_TOLERANCE)):
-                self._head.set_pan(angle, speed=30, timeout=0)
+                self._head.set_pan(angle, speed=0.3, timeout=0)
                 control_rate.sleep()
             command_rate.sleep()
 


### PR DESCRIPTION
Updates Examples to keep in sync with onboard `baxter_core_msgs`: https://github.com/RethinkRobotics/baxter_common/pull/72

 -   Updates the Head Pan range to be from 0->1.0 instead of 0->100.0
 -  Updates Navigator interface with onboard topic rework
