### PR TITLE
Add image_view dep to examples repo

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -42,5 +42,6 @@
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>baxter_core_msgs</run_depend>
   <run_depend>baxter_interface</run_depend>
+  <run_depend>image_view</run_depend>
 
 </package>


### PR DESCRIPTION
Installing this is not explicitly documented in the Baxter SDK, and this makes it automatic

*This PR is sponsored by [Vicarious](http://www.vicarious.com/)*